### PR TITLE
Remove force unwrap of viewModels

### DIFF
--- a/Chuck Norris Facts/App/Scenes/Facts/FactsList/FactsListViewController.swift
+++ b/Chuck Norris Facts/App/Scenes/Facts/FactsList/FactsListViewController.swift
@@ -14,7 +14,7 @@ import Lottie
 
 final class FactsListViewController: UIViewController {
 
-    var viewModel: FactsListViewModel!
+    var viewModel: FactsListViewModel?
 
     private let disposeBag = DisposeBag()
 
@@ -104,6 +104,8 @@ final class FactsListViewController: UIViewController {
     }
 
     private func setupBindings() {
+        guard let viewModel = viewModel else { return }
+
         rx.viewDidAppear
             .bind(to: viewModel.inputs.viewDidAppear)
             .disposed(by: disposeBag)

--- a/Chuck Norris Facts/App/Scenes/Facts/SearchFacts/SearchFactsViewController.swift
+++ b/Chuck Norris Facts/App/Scenes/Facts/SearchFacts/SearchFactsViewController.swift
@@ -12,7 +12,7 @@ import RxDataSources
 
 final class SearchFactsViewController: UIViewController {
 
-    var viewModel: SearchFactsViewModel!
+    var viewModel: SearchFactsViewModel?
 
     let disposeBag = DisposeBag()
 
@@ -109,6 +109,8 @@ final class SearchFactsViewController: UIViewController {
     }
 
     private func setupBindings() {
+        guard let viewModel = viewModel else { return }
+
         rx.viewWillAppear
             .bind(to: viewModel.inputs.viewWillAppear)
             .disposed(by: disposeBag)

--- a/Chuck Norris Facts/App/Scenes/Facts/SearchFacts/Suggestions/SuggestionsCell.swift
+++ b/Chuck Norris Facts/App/Scenes/Facts/SearchFacts/Suggestions/SuggestionsCell.swift
@@ -37,7 +37,7 @@ final class SuggestionsCell: UITableViewCell {
         }
     )
 
-    var viewModel: SuggestionsViewModel! {
+    var viewModel: SuggestionsViewModel? {
         didSet {
             self.setupBindings()
         }
@@ -71,6 +71,8 @@ final class SuggestionsCell: UITableViewCell {
     }
 
     private func setupBindings() {
+        guard let viewModel = viewModel else { return }
+
         collectionView.rx
             .setDelegate(self)
             .disposed(by: disposeBag)

--- a/Chuck Norris Facts/Core/Data/Storage/FactsStorage.swift
+++ b/Chuck Norris Facts/Core/Data/Storage/FactsStorage.swift
@@ -26,32 +26,40 @@ protocol FactsStorageType {
 }
 
 final class FactsStorage: FactsStorageType {
-    private let realm: Realm!
+    private let realm: Realm?
 
     init(realm: Realm? = nil) {
         self.realm = realm ?? (try? Realm())
     }
 
     func storeCategories(_ categories: [FactCategory]) {
+        guard let realm = realm else { return }
+
         try? realm.write {
             let entities = categories.map(FactCategoryEntity.init)
-            self.realm.add(entities, update: .modified)
+            realm.add(entities, update: .modified)
         }
     }
 
     func retrieveCategories() -> Observable<[FactCategory]> {
+        guard let realm = realm else { return .never() }
+
         let entities = realm.objects(FactCategoryEntity.self)
         return Observable.collection(from: entities).map { $0.map { $0.item } }
     }
 
     func storeSearch(searchTerm: String) {
+        guard let realm = realm else { return }
+
         try? realm.write {
             let entity = SearchEntity(searchTerm: searchTerm)
-            self.realm.add(entity, update: .modified)
+            realm.add(entity, update: .modified)
         }
     }
 
     func retrieveSearches() -> Observable<[String]> {
+        guard let realm = realm else { return .never() }
+
         let entities = realm.objects(SearchEntity.self).sorted(byKeyPath: "updatedAt", ascending: false)
         return Observable.collection(from: entities).map { $0.map { $0.searchTerm } }
     }


### PR DESCRIPTION
It's a bad practice of force unwrap of variables, this can lead crashes if someone that is new with the code base change something, so, let's keep these things as optionals.